### PR TITLE
[FIX] compilation error due to isspace() in usddeck.c

### DIFF
--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -236,7 +236,7 @@ TCHAR* f_gets_without_comments (
     if (c == '\n') {
       break;   /* Break on EOL */
     }
-    if (isspace(c)) {
+    if (isspace((int)c)) {
       continue; /* Strip whitespace */
     }
     if (c == '#') {
@@ -380,7 +380,7 @@ static void usdLogTask(void* prm)
         line = f_gets_without_comments(readBuffer, sizeof(readBuffer), &logFile);
         if (!line) break;
       }
-      
+
       while (line) {
         line = f_gets_without_comments(readBuffer, sizeof(readBuffer), &logFile);
         if (!line) break;


### PR DESCRIPTION
HINT: resolves error: array subscript has type 'char'
[-Werror=char-subscripts] as all warnings are treated as errors.
This error occurs when running the build.sh script from the crazyswarm (master branch) project. 